### PR TITLE
Adding Auckland Transport Open GIS Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This is a list of New Zealand Data and available APIs, Pull Requests are very we
 - Auckland Council
   - [Auckland Open Data](http://aucklandopendata.aucklandcouncil.opendata.arcgis.com/)
   - [Auckland Transport API](https://api.at.govt.nz/)
+  - [Auckland Transport Open GIS Data](http://data.atgis.opendata.arcgis.com/)
 - Wanganui District Council
   - [Full Datasets](http://wdc.wanganui.govt.nz/odata/xml/index.html)
   - [GIS data](http://maps.wanganui.govt.nz/geoserver/web/;jsessionid=h7wgq0v25vjm?wicket:bookmarkablePage=:org.geoserver.web.demo.MapPreviewPage)


### PR DESCRIPTION
Recently launched Open GIS Data portal - Launch announcement - https://www.linkedin.com/pulse/auckland-transport-gis-open-data-portal-ian-smith