### PR TITLE
Add DevStack NZ property APIs to Companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ This is a list of New Zealand Data and available APIs, Pull Requests are very we
 
 ### Companies
 
+- DevStack
+    - [Watercare IGC Calculator - free JSON API](https://devstack.co.nz/api/icg) - calculates Auckland's water and wastewater Infrastructure Growth Charge per dwelling, current rates
+    - [NZ Property Development Tools Catalogue - free JSON API](https://devstack.co.nz/api/tools) - machine-readable list of NZ property development tools and data sources
 - New Zealand Electricity Industry
 	- [Market Info](http://www.electricityinfo.co.nz/comitFta/ftapage.main)
 - NZ Post


### PR DESCRIPTION
Adds DevStack's two free NZ property data APIs under Companies.

Both are free JSON APIs, no auth, CORS open:

- /api/icg calculates Auckland's Watercare Infrastructure Growth Charge per dwelling at the current year's published rates (all catchments, residential and business modes)
- /api/tools is a machine-readable catalogue of NZ property development tools and datasets

Built by an Auckland development manager; rates are updated each 1 July when Watercare publishes the new schedule. Happy to adjust placement or format if you'd prefer them elsewhere.